### PR TITLE
ユーザー編集画面のビュー作成

### DIFF
--- a/app/controllers/admins/registrations_controller.rb
+++ b/app/controllers/admins/registrations_controller.rb
@@ -57,7 +57,7 @@ class Admins::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
@@ -78,8 +78,6 @@ class Admins::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
-
-  private
 
   def company_params
     params.require(:company).permit(:name, :opening_time, :closing_time)

--- a/app/controllers/employees/registrations_controller.rb
+++ b/app/controllers/employees/registrations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Employees::RegistrationsController < Devise::RegistrationsController
+  prepend_before_action :require_no_authentication, only: [:cancel]
+  prepend_before_action :authenticate_scope!, only: [:destroy]
   before_action :configure_sign_up_params, only: [:create]
   before_action :configure_account_update_params, only: [:update]
 
@@ -23,14 +25,48 @@ class Employees::RegistrationsController < Devise::RegistrationsController
 
   # GET /resource/edit
   def edit
-    session[:employee_id] = params[:id]
-    super
+    if admin_signed_in?
+      # self.resource = Employee.find(params[:employee_id])
+      self.resource = resource_class.to_adapter.get!(params[:employee_id])
+    else
+      authenticate_scope!
+      super
+    end
   end
 
   # PUT /resource
-  # def update
-  #   super
-  # end
+  def update
+    if admin_signed_in?
+      self.resource = resource_class.to_adapter.get!(params[:employee][:id])
+    else
+      self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+    end
+
+    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
+
+    if admin_signed_in?
+      resource_updated = update_resource_without_password(resource, account_update_params)
+    else
+      resource_updated = update_resource(resource, account_update_params)
+    end
+
+    yield resource if block_given?
+    if resource_updated
+      if is_flashing_format?
+        flash_key = update_needs_confirmation?(resource, prev_unconfirmed_email) ?
+          :update_needs_confirmation : :updated
+        set_flash_message :notice, flash_key
+      end
+      unless admin_signed_in?
+        bypass_sign_in resource, scope: resource_name
+      end
+      respond_with resource, location: after_update_path_for(resource)
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      respond_with resource
+    end
+  end
 
   # DELETE /resource
   # def destroy
@@ -46,7 +82,7 @@ class Employees::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
@@ -58,10 +94,22 @@ class Employees::RegistrationsController < Devise::RegistrationsController
     devise_parameter_sanitizer.permit(:account_update, keys: [:number, :last_name, :first_name, :joining_date, :email])
   end
 
+  def update_resource_without_password(resource, params)
+    resource.update_without_password(params)
+  end
+
   # The path used after sign up.
   # def after_sign_up_path_for(resource)
   #   super(resource)
   # end
+
+  def after_update_path_for(resource)
+    if admin_signed_in?
+      root_path
+    else
+      root_path   # スタッフのトップページ作成後に変更
+    end
+  end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -12,8 +12,8 @@ class Admin < ApplicationRecord
     false
   end
 
-  has_one  :company
-  has_many :employees
+  has_one  :company, dependent: :destroy
+  has_many :employees, dependent: :destroy
 
   with_options presence: true do
     validates :number

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -4,10 +4,12 @@ class Employee < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  attr_accessor :current_password
+
   def email_required?
     false
   end
-  
+
   def email_changed?
     false
   end

--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -65,7 +65,8 @@
           <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
         </div>
         <div class="field-label">
-          <%= f.label :current_password, '現在のパスワード' %> <i><br />(変更するには現在のパスワードが必要です)</i>
+          <%= f.label :current_password, '現在のパスワード' %><br />
+          <i>(変更するには現在のパスワードが必要です)</i>
         </div>
         <div class="field-input">
           <%= f.password_field :current_password, autocomplete: "current-password" %>

--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -1,63 +1,79 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "admins/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :joining_date, '入社日' %><br />
-    <%= f.date_field :joining_date, class: :form__text %>
+<div class="account-page">
+  <div class="account-page__inner--left">
+    <h2>Edit Account</h2>
+    <h5>責任者の情報を編集する</h5>
+    <%= button_to "アカウント削除", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %>
+    <br />
+    <div class="account-link">
+      <%= link_to "トップページへ戻る", :back %>
+    </div>
   </div>
+  <div class="account-page__inner--right">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <div class="field">
+        <%= render "admins/shared/error_messages", resource: resource %>
+        <div class="field-label">
+          <%= f.label :joining_date, '入社日' %>
+        </div>
+        <div class="field-input">
+          <%= f.date_field :joining_date %>
+        </div>
+        <div class="field-label">
+          <%= f.label :number, '社員番号' %>
+        </div>
+        <div class="field-input">
+          <%= f.text_field :number, autofocus: true, autocomplete: "employee_number" %>
+        </div>
+        <div class="field-label">
+          <%= f.label :last_name, '姓' %>
+        </div>
+        <div class="field-input">
+          <%= f.text_field :last_name %>
+        </div>
+        <div class="field-label">
+          <%= f.label :first_name, '名' %>
+        </div>
+        <div class="field-input">
+          <%= f.text_field :first_name %>
+        </div>
+        <div class="field-label">
+          <%= f.label :email, 'メールアドレス' %>
+        </div>
+        <div class="field-input">
+          <%= f.email_field :email, autocomplete: "email" %>
+        </div>
 
-  <div class="field">
-    <%= f.label :number, '社員番号' %><br />
-    <%= f.text_field :number, autofocus: true, autocomplete: "employee_number", class: :form__text %>
-  </div>
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+        <% end %>
 
-  <div class="field">
-    <%= f.label :last_name, '姓' %><br />
-    <%= f.text_field :last_name, class: :form__txst %>
-  </div>
-
-  <div class="field">
-    <%= f.label :first_name, '名' %><br />
-    <%= f.text_field :first_name, class: :form__text %>
-  </div>
-
-  <div class="field">
-    <%= f.label :email, 'メールアドレス' %><br />
-    <%= f.email_field :email, autocomplete: "email" %>
-  </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password, '新しいパスワード' %> <i>(変更したくない場合は空白にします)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %>文字以上</em>
+        <div class="field-label">
+          <%= f.label :password, '新しいパスワード' %>
+          <% if @minimum_password_length %>
+            <br />
+            <em><%= @minimum_password_length %>文字以上</em>
+          <% end %>
+          <i>(変更したくない場合は空白にします)</i>
+        </div>
+        <div class="field-input">
+          <%= f.password_field :password, autocomplete: "new-password" %>
+        </div>
+        <div class="field-label">
+          <%= f.label :password_confirmation, '新しいパスワード確認' %>
+        </div>
+        <div class="field-input">
+          <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+        </div>
+        <div class="field-label">
+          <%= f.label :current_password, '現在のパスワード' %> <i><br />(変更するには現在のパスワードが必要です)</i>
+        </div>
+        <div class="field-input">
+          <%= f.password_field :current_password, autocomplete: "current-password" %>
+        </div>
+        <div class="actions">
+          <%= f.submit "変更", class: "btn" %>
+        </div>
+      </div>
     <% end %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, '新しいパスワード確認' %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password, '現在のパスワード' %> <i>(変更するには現在のパスワードが必要です)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/admins/registrations/new.html.erb
+++ b/app/views/admins/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <div class="account-page">
   <div class="account-page__inner--left">
-    <h2>新規登録</h2>
+    <h2>Sign up</h2>
     <h5>新しくユーザーを登録する（責任者専用）</h5>
     <%= render "admins/shared/links" %>
   </div>

--- a/app/views/admins/registrations/new_company.html.erb
+++ b/app/views/admins/registrations/new_company.html.erb
@@ -1,6 +1,6 @@
 <div class="account-page">
   <div class="account-page__inner--left">
-    <h2>新規登録</h2>
+    <h2>Sign up</h2>
     <h5>店舗情報を登録する</h5>
     <%= render "admins/shared/links" %>
   </div>

--- a/app/views/admins_home/index.html.erb
+++ b/app/views/admins_home/index.html.erb
@@ -25,7 +25,7 @@
       <div class="home-content1"><%= employee.number %></div>
       <div class="home-content2"><%= employee.last_name %><%= employee.first_name %></div>
       <div class="home-content3"><%= employee.joining_date %></div>
-      <%= link_to '退職', admins_home_path(employee.id), method: :delete, class: "staff-delete-btn" %>
+      <%= link_to '退職', admins_home_path(employee.id), data: { confirm: "Are you sure?" }, method: :delete, class: "staff-delete-btn" %>
     </div>
   <% end %>
 

--- a/app/views/admins_home/index.html.erb
+++ b/app/views/admins_home/index.html.erb
@@ -25,6 +25,7 @@
       <div class="home-content1"><%= employee.number %></div>
       <div class="home-content2"><%= employee.last_name %><%= employee.first_name %></div>
       <div class="home-content3"><%= employee.joining_date %></div>
+      <%= link_to '編集', edit_employee_registration_path(employee_id: employee.id) %>
       <%= link_to '退職', admins_home_path(employee.id), data: { confirm: "Are you sure?" }, method: :delete, class: "staff-delete-btn" %>
     </div>
   <% end %>

--- a/app/views/employees/registrations/edit.html.erb
+++ b/app/views/employees/registrations/edit.html.erb
@@ -1,63 +1,81 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "employees/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :joining_date, '入社日' %><br />
-    <%= f.date_field :joining_date, class: :form__text %>
+<div class="account-page">
+  <div class="account-page__inner--left">
+    <h2>Staff編集</h2>
+    <h5>売場スタッフの情報を編集する</h5>
+    <%= button_to "退職", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %>
+    <br />
+    <div class="account-link">
+      <%= link_to "トップページへ戻る", :back %>
+    </div>
   </div>
 
-  <div class="field">
-    <%= f.label :number, '社員番号' %><br />
-    <%= f.text_field :number, autofocus: true, autocomplete: "employee_number", class: :form__text %>
-  </div>
+  <div class="account-page__inner--right">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <div class="field">
+        <%= render "employees/shared/error_messages", resource: resource %>
+        <div class="field-label">
+          <%= f.label :joining_date, '入社日' %>
+        </div>
+        <div class="field-input">
+          <%= f.date_field :joining_date %>
+        </div>
+        <div class="field-label">
+          <%= f.label :number, '社員番号' %>
+        </div>
+        <div class="field-input">
+          <%= f.text_field :number, autofocus: true, autocomplete: "employee_number" %>
+        </div>
+        <div class="field-label">
+          <%= f.label :last_name, '姓' %>
+        </div>
+        <div class="field-input">
+          <%= f.text_field :last_name %>
+        </div>
+        <div class="field-label">
+          <%= f.label :first_name, '名' %>
+        </div>
+        <div class="field-input">
+          <%= f.text_field :first_name %>
+        </div>
+        <div class="field-label">
+          <%= f.label :email, 'メールアドレス' %>
+        </div>
+        <div class="field-input">
+          <%= f.email_field :email, autocomplete: "email" %>
+        </div>
 
-  <div class="field">
-    <%= f.label :last_name, '姓' %><br />
-    <%= f.text_field :last_name, class: :form__txst %>
-  </div>
+        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+          <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+        <% end %>
 
-  <div class="field">
-    <%= f.label :first_name, '名' %><br />
-    <%= f.text_field :first_name, class: :form__text %>
-  </div>
-
-  <div class="field">
-    <%= f.label :email, 'メールアドレス' %><br />
-    <%= f.email_field :email, autocomplete: "email" %>
-  </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password, '新しいパスワード' %> <i>(変更したくない場合は空白にします)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %>文字以上</em>
+        <div class="field-label">
+          <%= f.label :password, '新しいパスワード' %>
+          <% if @minimum_password_length %>
+            <br />
+            <em><%= @minimum_password_length %>文字以上</em>
+          <% end %>
+          <i>(変更したくない場合は空白にします)</i>
+        </div>
+        <div class="field-input">
+          <%= f.password_field :password, autocomplete: "new-password" %>
+        </div>
+        <div class="field-label">
+          <%= f.label :password_confirmation, '新しいパスワード確認' %>
+        </div>
+        <div class="field-input">
+          <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+        </div>
+        <div class="field-label">
+          <%= f.label :current_password, '現在のパスワード' %><br />
+          <i>(変更するには現在のパスワードが必要です)</i>
+        </div>
+        <div class="field-input">
+          <%= f.password_field :current_password, autocomplete: "current-password" %>
+        </div>
+        <div class="actions">
+          <%= f.submit "変更", class: "btn" %>
+        </div>
+      </div>
     <% end %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, '新しいパスワード確認' %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password, '現在のパスワード' %> <i>(変更するには現在のパスワードが必要です)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/employees/registrations/edit.html.erb
+++ b/app/views/employees/registrations/edit.html.erb
@@ -8,70 +8,74 @@
       <%= link_to "トップページへ戻る", :back %>
     </div>
   </div>
-
   <div class="account-page__inner--right">
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
       <div class="field">
         <%= render "employees/shared/error_messages", resource: resource %>
-        <div class="field-label">
-          <%= f.label :joining_date, '入社日' %>
-        </div>
-        <div class="field-input">
-          <%= f.date_field :joining_date %>
-        </div>
-        <div class="field-label">
-          <%= f.label :number, '社員番号' %>
-        </div>
-        <div class="field-input">
-          <%= f.text_field :number, autofocus: true, autocomplete: "employee_number" %>
-        </div>
-        <div class="field-label">
-          <%= f.label :last_name, '姓' %>
-        </div>
-        <div class="field-input">
-          <%= f.text_field :last_name %>
-        </div>
-        <div class="field-label">
-          <%= f.label :first_name, '名' %>
-        </div>
-        <div class="field-input">
-          <%= f.text_field :first_name %>
-        </div>
-        <div class="field-label">
-          <%= f.label :email, 'メールアドレス' %>
-        </div>
-        <div class="field-input">
-          <%= f.email_field :email, autocomplete: "email" %>
-        </div>
-
-        <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-          <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+        <%= f.hidden_field :id, value: @employee.id %>
+        <% if admin_signed_in? %>
+          <div class="field-label">
+            <%= f.label :joining_date, '入社日' %>
+          </div>
+          <div class="field-input">
+            <%= f.date_field :joining_date %>
+          </div>
+          <div class="field-label">
+            <%= f.label :number, '社員番号' %>
+          </div>
+          <div class="field-input">
+            <%= f.text_field :number, autofocus: true, autocomplete: "employee_number" %>
+          </div>
+          <div class="field-label">
+            <%= f.label :last_name, '姓' %>
+          </div>
+          <div class="field-input">
+            <%= f.text_field :last_name %>
+          </div>
+          <div class="field-label">
+            <%= f.label :first_name, '名' %>
+          </div>
+          <div class="field-input">
+            <%= f.text_field :first_name %>
+          </div>
         <% end %>
+        <% if employee_signed_in? %>
+          <div class="field-label">
+            <%= f.label :email, 'メールアドレス' %>
+          </div>
+          <div class="field-input">
+            <%= f.email_field :email, autocomplete: "email" %>
+          </div>
 
-        <div class="field-label">
-          <%= f.label :password, '新しいパスワード' %>
-          <% if @minimum_password_length %>
-            <br />
-            <em><%= @minimum_password_length %>文字以上</em>
+          <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+            <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
           <% end %>
-          <i>(変更したくない場合は空白にします)</i>
-        </div>
-        <div class="field-input">
-          <%= f.password_field :password, autocomplete: "new-password" %>
-        </div>
-        <div class="field-label">
-          <%= f.label :password_confirmation, '新しいパスワード確認' %>
-        </div>
-        <div class="field-input">
-          <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-        </div>
-        <div class="field-label">
-          <%= f.label :current_password, '現在のパスワード' %><br />
-          <i>(変更するには現在のパスワードが必要です)</i>
-        </div>
-        <div class="field-input">
-          <%= f.password_field :current_password, autocomplete: "current-password" %>
-        </div>
+
+          <div class="field-label">
+            <%= f.label :password, '新しいパスワード' %>
+            <% if @minimum_password_length %>
+              <br />
+              <em><%= @minimum_password_length %>文字以上</em>
+            <% end %>
+            <i>(変更したくない場合は空白にします)</i>
+          </div>
+          <div class="field-input">
+            <%= f.password_field :password, autocomplete: "new-password" %>
+          </div>
+          <div class="field-label">
+            <%= f.label :password_confirmation, '新しいパスワード確認' %>
+          </div>
+          <div class="field-input">
+            <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+          </div>
+          <div class="field-label">
+            <%= f.label :current_password, '現在のパスワード' %><br />
+            <i>(変更するには現在のパスワードが必要です)</i>
+          </div>
+          <div class="field-input">
+            <%= f.password_field :current_password, autocomplete: "current-password" %>
+          </div>
+        <% end %>
         <div class="actions">
           <%= f.submit "変更", class: "btn" %>
         </div>

--- a/app/views/employees/registrations/new.html.erb
+++ b/app/views/employees/registrations/new.html.erb
@@ -2,6 +2,9 @@
   <div class="account-page__inner--left">
     <h2>Staff登録</h2>
     <h5>新しく売場スタッフを登録する</h5>
+    <div class="account-link">
+      <%= link_to "トップページへ戻る", :back %>
+    </div>
   </div>
   <div class="account-page__inner--right">
     <%= form_with model: @employee, url: employee_registration_path, local: true do |f| %>


### PR DESCRIPTION
# What
- ユーザー情報の編集画面のビュー作成
- employee編集機能の権限を設定

# Why
責任者は全スタッフの入社日と社員番号と名前、スタッフは自身のemailとパスワードのみを変更できるようにするため。